### PR TITLE
Store project spec link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # traveler
+https://frontend.turing.io/projects/travel-tracker.html


### PR DESCRIPTION
### what
links project spec in body of readme

### why
easy access to spec during initial build

### where
`readme.md`
